### PR TITLE
vms/shell-example: Add bridge networking support

### DIFF
--- a/vms/shell-example/flake.nix
+++ b/vms/shell-example/flake.nix
@@ -24,12 +24,23 @@
               storeOnDisk = true;
               writableStoreOverlay = "/nix/.rw-store";
               hypervisor = "cloud-hypervisor";
+              interfaces = [{
+                type = "tap";
+                id = "vm-shell-example";
+                mac = "02:00:00:00:00:01";
+              }];
             };
           }
           (
             # configuration.nix
             { pkgs, lib, ... }: {
               networking.hostName = name;
+              networking.useNetworkd = true;
+              systemd.network.enable = true;
+              systemd.network.networks."20-lan" = {
+                matchConfig.Type = "ether";
+                networkConfig.DHCP = "yes";
+              };
               system.stateVersion = lib.trivial.release;
               services.getty.autologinUser = "root";
               nix = {
@@ -41,8 +52,17 @@
             }
           )
         ];
-        # TODO: Add networking via bridge
-        # https://astro.github.io/microvm.nix/simple-network.html
+        # Host configuration needed for bridge networking:
+        # Option 1 - Using systemd-networkd (automatically handles TAP interfaces):
+        # networking.useNetworkd = true; systemd.network.enable = true;
+        # systemd.network.netdevs."br0".netdevConfig = { Name = "br0"; Kind = "bridge"; };
+        # systemd.network.networks."10-lan".matchConfig.Name = ["eno1" "vm-*"];  # vm-* auto-adds TAP
+        # systemd.network.networks."10-lan".networkConfig.Bridge = "br0";
+        # 
+        # Option 2 - Using NetworkManager (requires manual TAP addition):
+        # networking.bridges.br0.interfaces = [ "eno1" ];  # Creates br0 bridge
+        # networking.interfaces.br0.useDHCP = true;
+        # Manual: ip link set vm-shell-example master br0  # TAP created after VM starts
       };
     };
   };


### PR DESCRIPTION
## Summary
• Implement TAP interface networking with systemd-networkd configuration for the shell-example microvm
• Add comprehensive documentation showing both systemd-networkd and NetworkManager host bridge setup options

## Test plan
- [ ] Build the microvm example: `nix build .#shell-example`
- [ ] Verify TAP interface is created when VM starts
- [ ] Test network connectivity with appropriate host bridge configuration