### PR TITLE
Update git-pr to track origin branch

### DIFF
--- a/home/bin/git-pr
+++ b/home/bin/git-pr
@@ -28,12 +28,20 @@ checkout() {
     fi
     log "Checking out PR ${number}-${ref}"
     git fetch origin "pull/$1/head:pull/$1-${ref}"
-    git checkout "pull/$1-${ref}"
+    git checkout "pull/$1-${ref}" || return $?
+
+    # Try to set upstream if the branch exists on origin
+    if git ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
+        log "Found $ref on origin, setting upstream..."
+        git fetch origin "$ref:refs/remotes/origin/$ref"
+        git branch --set-upstream-to="origin/$ref"
+    fi
+    return 0
 }
 
 if [[ $1 ]]; then
     # Select a specific PR number
-    checkout "$1"
+    checkout "$1" "$2"
     exit $?
 fi
 


### PR DESCRIPTION
Updated `home/bin/git-pr` to:
1. Pass the second argument (branch name) to the `checkout` function when running in non-interactive mode.
2. In the `checkout` function, check if the checked-out branch exists on `origin` using `git ls-remote`.
3. If it exists, fetch it and set the local branch to track `origin/$ref`.
4. Ensure `git checkout` failure returns an error code properly.

---
*PR created automatically by Jules for task [5612957390479875223](https://jules.google.com/task/5612957390479875223) started by @shazow*