### PR TITLE
Add 8GB swapfile to shazowic-mollusk NixOS config

### DIFF
--- a/hosts/shazowic-mollusk/configuration.nix
+++ b/hosts/shazowic-mollusk/configuration.nix
@@ -24,6 +24,12 @@ in {
 
   # Synology-hosted VM defaults
   services.qemuGuest.enable = true;
+  swapDevices = [
+    {
+      device = "/swapfile";
+      size = 8 * 1024; # 8GB in MiB
+    }
+  ];
 
   services.openssh = {
     enable = true;


### PR DESCRIPTION
### Motivation
- Provide swap space for the Synology-hosted VM to avoid OOMs and support workloads that need additional memory by default.

### Description
- Add a `swapDevices` entry to `hosts/shazowic-mollusk/configuration.nix` that creates a `/swapfile` with size `8 * 1024` (8GB in MiB).

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c35898bed483259b8b8c89354e4d6b)