### PR TITLE
Fix shazowic-urchin user bus over SSH

### DIFF
--- a/hosts/shazowic-urchin/configuration.nix
+++ b/hosts/shazowic-urchin/configuration.nix
@@ -67,6 +67,9 @@ in
     enable = true;
     startWhenNeeded = true;
     settings = {
+      # Keep SSH logins attached to a logind/PAM session so systemd --user
+      # receives XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS.
+      UsePAM = true;
       PasswordAuthentication = false;
       KbdInteractiveAuthentication = false;
     };
@@ -93,6 +96,7 @@ in
       "kvm"
     ];
     isNormalUser = true;
+    linger = true; # Keep the user manager/bus available for systemd --user over SSH.
 
     openssh.authorizedKeys.keyFiles = [ shazowGithubKeys ];
   };


### PR DESCRIPTION
## Summary
- explicitly keep OpenSSH PAM enabled on `shazowic-urchin` so SSH sessions attach to logind/PAM and get the user bus environment
- enable declarative lingering for the primary `shazow` user, matching the existing `agent` lingering setup

## Verification
- `nix run nixpkgs#nixfmt-rfc-style -- hosts/shazowic-urchin/configuration.nix`
- `nix eval .#nixosConfigurations.shazowic-urchin.config.services.openssh.settings.UsePAM` → `true`
- `nix eval .#nixosConfigurations.shazowic-urchin.config.users.users.shazow.linger` → `true`
- `nix eval .#nixosConfigurations.shazowic-urchin.config.users.users.agent.linger` → `true`
- `nix build .#nixosConfigurations.shazowic-urchin.config.system.build.toplevel --no-link --dry-run`
