### PR TITLE
Allow agent to read system journal

### DIFF
--- a/hosts/shazowic-urchin/configuration.nix
+++ b/hosts/shazowic-urchin/configuration.nix
@@ -100,7 +100,10 @@ in
     openssh.authorizedKeys.keyFiles = [ shazowGithubKeys ];
   };
   users.users."agent" = {
-    extraGroups = lib.mkAfter [ "kvm" ];
+    extraGroups = lib.mkAfter [
+      "kvm"
+      "systemd-journal"
+    ];
     isNormalUser = true;
     linger = true; # Need this for running systemd services without being logged in
 


### PR DESCRIPTION
## Summary
- add the `agent` user on `shazowic-urchin` to the `systemd-journal` group
- preserves existing `kvm` group membership via `lib.mkAfter`

## Verification
- `nix eval .#nixosConfigurations.shazowic-urchin.config.users.users.agent.extraGroups --json` → `["kvm","systemd-journal"]`
- `nix build .#nixosConfigurations.shazowic-urchin.config.system.build.toplevel --no-link --dry-run` → succeeded and produced the expected dry-run build plan

## Notes
- `systemd-journal` is the narrow group that allows full `journalctl` access without adding broader admin privileges like `wheel`.
- This does not switch the host immediately; it will take effect after the host rebuilds/switches.