### PR TITLE
Reduce shazowic-urchin D-Bus power profile noise

### DIFF
--- a/hosts/shazowic-urchin/configuration.nix
+++ b/hosts/shazowic-urchin/configuration.nix
@@ -83,7 +83,8 @@ in
 
   services.tuned = {
     enable = true;
-    ppdSettings.main.default = "power-saver";
+    ppdSupport = false;
+    recommend.powersave = { };
   };
 
   users.users.${primaryUsername} = {


### PR DESCRIPTION
## Summary
- disable TuneD's power-profiles-daemon compatibility layer on headless `shazowic-urchin`
- keep TuneD enabled and select the native `powersave` recommendation instead of `ppdSettings.main.default`
- removes the UPower dependency from this host and reduces duplicated D-Bus activatable service noise

## Verification
- `nix run nixpkgs#nixfmt -- hosts/shazowic-urchin/configuration.nix`
- `nix eval .#nixosConfigurations.shazowic-urchin.config.services.tuned.ppdSupport --json` → `false`
- `nix eval .#nixosConfigurations.shazowic-urchin.config.services.tuned.recommend --json` → `{"powersave":{}}`
- `nix eval .#nixosConfigurations.shazowic-urchin.config.services.upower.enable --json` → `false`
- `nix eval .#nixosConfigurations.shazowic-urchin.config.services.dbus.packages --apply 'map (p: p.name or (builtins.baseNameOf p.outPath))' --json` → `["dbus-1.16.2","system-path","tuned-2.27.0","thermald-2.5.11","polkit-127"]`
- `nix build .#nixosConfigurations.shazowic-urchin.config.system.build.toplevel --no-link --dry-run` → succeeded and produced the expected dry-run build plan

## Notes
This intentionally does not try to globally curate `services.dbus.packages`; that would be broader and more brittle. This keeps the change local to the headless host's TuneD setup.
