### PR TITLE
Schedule weekly shazowic-urchin upgrades

### DIFF
--- a/hosts/shazowic-urchin/configuration.nix
+++ b/hosts/shazowic-urchin/configuration.nix
@@ -32,28 +32,21 @@ in
   system.autoUpgrade = {
     enable = true;
     flake = "github:shazow/nixfiles#shazowic-urchin";
-    dates = "04:00";
-    randomizedDelaySec = "45min";
+    dates = "Tue *-*-* 04:00:00 America/New_York";
     persistent = true;
     allowReboot = true;
-    rebootWindow = {
-      lower = "04:00";
-      upper = "06:00";
-    };
-    runGarbageCollection = true;
+    runGarbageCollection = false;
   };
 
   nix.gc = {
     automatic = true;
-    dates = "weekly";
-    randomizedDelaySec = "1h";
+    dates = "Thu *-*-* 04:00:00 America/New_York";
     options = "--delete-older-than 30d";
   };
 
   nix.optimise = {
     automatic = true;
-    dates = [ "weekly" ];
-    randomizedDelaySec = "1h";
+    dates = [ "Thu *-*-* 04:00:00 America/New_York" ];
   };
 
   swapDevices = [

--- a/hosts/shazowic-urchin/configuration.nix
+++ b/hosts/shazowic-urchin/configuration.nix
@@ -46,7 +46,7 @@ in
 
   nix.optimise = {
     automatic = true;
-    dates = [ "Thu *-*-* 04:00:00 America/New_York" ];
+    dates = [ "Thu *-*-* 05:00:00 America/New_York" ];
   };
 
   swapDevices = [


### PR DESCRIPTION
## Summary
- move `shazowic-urchin` NixOS auto-upgrades from daily to Tuesdays at 4am ET
- run Nix GC on Thursdays at 4am ET
- run Nix store optimisation on Thursdays at 5am ET so it does not overlap GC
- disable `system.autoUpgrade.runGarbageCollection` so GC only follows the Thursday schedule
- remove randomized delays so the requested wall-clock times are exact systemd calendar events

## Verification
- `systemd-analyze calendar 'Tue *-*-* 04:00:00 America/New_York' 'Tue *-*-* 05:00:00 America/New_York' 'Thu *-*-* 04:00:00 America/New_York' 'Thu *-*-* 05:00:00 America/New_York'` → current EDT elapses are Tue 08:00 UTC, Tue 09:00 UTC, Thu 08:00 UTC, Thu 09:00 UTC
- `nix eval .#nixosConfigurations.shazowic-urchin.config.system.autoUpgrade.dates --json` → `"Tue *-*-* 04:00:00 America/New_York"`
- `nix eval .#nixosConfigurations.shazowic-urchin.config.system.autoUpgrade.runGarbageCollection --json` → `false`
- `nix eval .#nixosConfigurations.shazowic-urchin.config.nix.gc.dates --json` → `["Thu *-*-* 04:00:00 America/New_York"]`
- `nix eval .#nixosConfigurations.shazowic-urchin.config.nix.optimise.dates --json` → `["Thu *-*-* 05:00:00 America/New_York"]`
- `nix build .#nixosConfigurations.shazowic-urchin.config.system.build.toplevel --no-link --dry-run` → succeeded and produced the expected dry-run build plan

## Notes
Home Manager auto-upgrade cadence is managed in the agent account's Home Manager repo, so I updated that separately to Tuesday 5am ET and verified `home-manager build --flake .#agent` succeeds.
