### PR TITLE
Enable Flatpak via nix-flatpak and add selected Flatpak apps to home manager

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
 
     home-manager.url = "github:nix-community/home-manager/release-26.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    nix-flatpak.url = "github:gmodena/nix-flatpak/v0.7.0";
     nixos-hardware.url = "github:nixos/nixos-hardware";
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -1,4 +1,4 @@
-{ pkgs, username, ... }:
+{ pkgs, username, inputs, ... }:
 
 {
   home.packages = with pkgs; [
@@ -6,9 +6,19 @@
   ];
 
   imports = [
+    inputs.nix-flatpak.homeManagerModules.nix-flatpak
     ./modules/wayland
     ./common/apps.nix
   ];
+
+  services.flatpak = {
+    enable = true;
+    packages = [
+      "com.discordapp.Discord"
+      "md.obsidian.Obsidian"
+      "org.telegram.desktop"
+    ];
+  };
 
   nixfiles.wayland.enable = true;
 


### PR DESCRIPTION
### Motivation

- Provide Flatpak support in the home-manager configuration so sandboxed desktop apps (Discord, Obsidian, Telegram) can be managed consistently.

### Description

- Add `nix-flatpak` as a flake input (`github:gmodena/nix-flatpak/v0.7.0`) to the top-level `flake.nix`.
- Update `home/desktop.nix` function signature to accept `inputs` and import `inputs.nix-flatpak.homeManagerModules.nix-flatpak` into `imports`.
- Enable `services.flatpak` in `home/desktop.nix` and declare the Flatpak packages `com.discordapp.Discord`, `md.obsidian.Obsidian`, and `org.telegram.desktop`.
- Leave existing Wayland, xresources, and other home settings unchanged.

### Testing

- Ran `nix flake check` against the flake and it completed successfully.
- Ran `home-manager build` for the updated desktop profile and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b5e6e198083258d7a159c3af1d603)